### PR TITLE
Implement timeout for dnf update checks and improve output readability

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+#
+# Linux System Utils Deployment Script
+# Deploys scripts to XDG base directories
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default locations based on XDG Base Directory Specification
+XDG_BIN_HOME="${XDG_BIN_HOME:-$HOME/.local/bin}"
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+
+# Repo and installation directories
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="${XDG_DATA_HOME}/linux-system-utils"
+BIN_DIR="${XDG_BIN_HOME}"
+CONFIG_DIR="${XDG_CONFIG_HOME}/linux-system-utils"
+
+# Define script categories and their installation paths
+declare -A SCRIPT_DIRS
+SCRIPT_DIRS["system/info"]="${INSTALL_DIR}/system/info"
+SCRIPT_DIRS["package-management"]="${INSTALL_DIR}/package-management"
+SCRIPT_DIRS["power"]="${INSTALL_DIR}/power"
+
+# Print usage information
+print_usage() {
+  echo -e "${BLUE}Linux System Utils - Deployment Script${NC}"
+  echo
+  echo "Usage: $0 [OPTIONS]"
+  echo
+  echo "Options:"
+  echo "  -h, --help        Show this help message"
+  echo "  -d, --dev         Install from current directory (development mode)"
+  echo "  -m, --main        Install from main branch (default)"
+  echo "  -f, --force       Force installation (overwrite existing files)"
+  echo "  -v, --verbose     Verbose output"
+  echo "  -t, --target DIR  Specify custom installation directory"
+  echo
+  echo "Example:"
+  echo "  $0 --dev          # Install from current directory"
+  echo "  $0 --main         # Install from main branch"
+  echo "  $0 --target ~/scripts # Install to custom directory"
+}
+
+# Log messages with colors based on type
+log_info() {
+  if [[ "$VERBOSE" == "true" ]]; then
+    echo -e "${BLUE}[INFO]${NC} $1"
+  fi
+}
+
+log_success() {
+  echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+  echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+# Check if a command exists
+command_exists() {
+  command -v "$1" &> /dev/null
+}
+
+# Create directory if it doesn't exist
+ensure_dir_exists() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    log_info "Creating directory: $dir"
+    mkdir -p "$dir"
+  fi
+}
+
+# Copy script with proper permissions
+copy_script() {
+  local src="$1"
+  local dest="$2"
+  local base_dest_dir="$(dirname "$dest")"
+
+  ensure_dir_exists "$base_dest_dir"
+
+  if [[ -f "$dest" && "$FORCE" != "true" ]]; then
+    log_warn "File already exists: $dest (use --force to overwrite)"
+    return 0
+  fi
+
+  cp "$src" "$dest"
+  chmod +x "$dest"
+  log_info "Installed: $dest"
+}
+
+# Create symbolic links in bin directory
+create_symlinks() {
+  ensure_dir_exists "$BIN_DIR"
+
+  # Find all executable scripts
+  find "$INSTALL_DIR" -type f -name "*.sh" | while read script; do
+    local script_name="$(basename "$script" .sh)"
+    local link_path="$BIN_DIR/$script_name"
+
+    # Skip if link exists and not forcing
+    if [[ -L "$link_path" && "$FORCE" != "true" ]]; then
+      log_warn "Symlink already exists: $link_path (use --force to overwrite)"
+      continue
+    fi
+
+    # Remove existing symlink or file if it exists
+    if [[ -e "$link_path" ]]; then
+      rm "$link_path"
+    fi
+
+    ln -sf "$script" "$link_path"
+    log_info "Created symlink: $link_path -> $script"
+  done
+}
+
+# Install from current directory (development mode)
+install_from_dev() {
+  log_info "Installing from development directory..."
+
+  # Create installation directories
+  ensure_dir_exists "$INSTALL_DIR"
+  ensure_dir_exists "$CONFIG_DIR"
+
+  # Install scripts by category
+  for dir in "${!SCRIPT_DIRS[@]}"; do
+    local source_dir="${REPO_DIR}/${dir}"
+    local target_dir="${SCRIPT_DIRS[$dir]}"
+
+    if [[ -d "$source_dir" ]]; then
+      ensure_dir_exists "$target_dir"
+
+      # Find all shell scripts in this category
+      find "$source_dir" -type f -name "*.sh" | while read script; do
+        local script_name="$(basename "$script")"
+        copy_script "$script" "${target_dir}/${script_name}"
+      done
+    else
+      log_warn "Directory not found: $source_dir"
+    fi
+  done
+
+  # Create symlinks for easy access
+  create_symlinks
+
+  log_success "Development installation complete!"
+  log_info "Scripts installed to: $INSTALL_DIR"
+  log_info "Symlinks created in: $BIN_DIR"
+}
+
+# Install from main branch by cloning directly to the installation directory
+install_from_main() {
+  log_info "Installing from main branch..."
+
+  # Check if git is available
+  if ! command_exists git; then
+    log_error "Git is not installed. Please install git first."
+    exit 1
+  fi
+
+  # Clean installation directory if it exists and force is enabled
+  if [[ -d "$INSTALL_DIR" ]]; then
+    if [[ "$FORCE" == "true" ]]; then
+      log_info "Removing existing installation directory..."
+      rm -rf "$INSTALL_DIR"
+    else
+      log_warn "Installation directory already exists: $INSTALL_DIR"
+      log_warn "Use --force to reinstall from main branch"
+      exit 1
+    fi
+  fi
+
+  # Create parent directories
+  ensure_dir_exists "$(dirname "$INSTALL_DIR")"
+
+  # Clone directly to the installation directory
+  local repo_url="https://github.com/cyber-syntax/linux-system-utils.git"
+  log_info "Cloning repository to: $INSTALL_DIR"
+
+  if ! git clone --depth 1 --branch main "$repo_url" "$INSTALL_DIR"; then
+    log_error "Failed to clone repository."
+    exit 1
+  fi
+
+  # Reorganize files if needed - if the repository structure doesn't match our expected structure
+  # Check if we have the expected directory structure
+  local has_expected_structure=true
+  for dir in "${!SCRIPT_DIRS[@]}"; do
+    if [[ ! -d "$INSTALL_DIR/$dir" ]]; then
+      has_expected_structure=false
+      break
+    fi
+  done
+
+  if [[ "$has_expected_structure" == "false" ]]; then
+    log_info "Repository structure differs from expected. Reorganizing..."
+
+    # Create a temporary directory for reorganization
+    local temp_dir="$(mktemp -d)"
+
+    # Look for script files in the repository and move them to the appropriate category
+    find "$INSTALL_DIR" -type f -name "*.sh" | while read script; do
+      local script_name="$(basename "$script")"
+      local script_path="$(dirname "$script")"
+
+      # Determine script category from path or content
+      local category=""
+      if [[ "$script_path" == *"/system/info"* ]]; then
+        category="system/info"
+      elif [[ "$script_path" == *"/package-management"* ]]; then
+        category="package-management"
+      elif [[ "$script_path" == *"/power"* ]]; then
+        category="power"
+      else
+        # Default category based on script name or content
+        if [[ "$script_name" == *"storage"* ]]; then
+          category="system/info"
+        elif [[ "$script_name" == *"package"* || "$script_name" == *"flatpak"* ]]; then
+          category="package-management"
+        elif [[ "$script_name" == *"power"* || "$script_name" == *"bright"* ]]; then
+          category="power"
+        else
+          # Examine content for hints about category
+          if grep -q "storage\|disk\|memory\|cpu" "$script"; then
+            category="system/info"
+          elif grep -q "package\|dnf\|apt\|flatpak" "$script"; then
+            category="package-management"
+          elif grep -q "power\|battery\|brightness\|suspend" "$script"; then
+            category="power"
+          else
+            # If we can't determine, put in a misc category
+            category="misc"
+          fi
+        fi
+      fi
+
+      # Create category directory in temp dir
+      ensure_dir_exists "$temp_dir/$category"
+
+      # Copy script to temp directory
+      cp "$script" "$temp_dir/$category/"
+      chmod +x "$temp_dir/$category/$script_name"
+    done
+
+    # Clean installation directory except .git
+    find "$INSTALL_DIR" -mindepth 1 -not -path "$INSTALL_DIR/.git*" -delete
+
+    # Move reorganized files back to installation directory
+    cp -r "$temp_dir/"* "$INSTALL_DIR/"
+
+    # Clean up
+    rm -rf "$temp_dir"
+  fi
+
+  # Create symlinks for easy access
+  create_symlinks
+
+  log_success "Main branch installation complete!"
+  log_info "Scripts installed to: $INSTALL_DIR"
+  log_info "Symlinks created in: $BIN_DIR"
+}
+
+# Parse command-line arguments
+MODE="main"  # Default mode is main branch
+FORCE="false"
+VERBOSE="false"
+CUSTOM_INSTALL_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    -d|--dev)
+      MODE="dev"
+      shift
+      ;;
+    -m|--main)
+      MODE="main"
+      shift
+      ;;
+    -f|--force)
+      FORCE="true"
+      shift
+      ;;
+    -v|--verbose)
+      VERBOSE="true"
+      shift
+      ;;
+    -t|--target)
+      if [[ -n "$2" ]]; then
+        CUSTOM_INSTALL_DIR="$2"
+        INSTALL_DIR="$CUSTOM_INSTALL_DIR"
+        shift 2
+      else
+        log_error "Option --target requires a directory argument."
+        exit 1
+      fi
+      ;;
+    *)
+      log_error "Unknown option: $1"
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
+# Run installation based on selected mode
+if [[ "$MODE" == "dev" ]]; then
+  install_from_dev
+else
+  install_from_main
+fi
+
+exit 0

--- a/package-management/fedora-flatpak-status.sh
+++ b/package-management/fedora-flatpak-status.sh
@@ -1,66 +1,122 @@
 #!/bin/bash
+# Copyright (c) 2025, Cyber-Syntax Serif
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 # This script checks for available Fedora (dnf) and Flatpak updates,
 # and prints a summary in the format:
 # Fedora: <dnf count> | Flatpak: <flatpak count>
 
-# ------------- DNF (Fedora) Update Info -------------
-# Use dnf check-update with a timeout to prevent hanging on GPG key prompts
-# Exit code 100 means updates are available, 0 means no updates
-# Use -y to automatically answer yes to any prompts like GPG key imports
+# --- Constants ---
 
-# Create a function to run dnf with a timeout
-run_dnf_with_timeout() {
+FEDORA_ICON=$'\uf30a' # FontAwesome Fedora logo
+DNF_EXIT_OK=0
+DNF_EXIT_UPDATES_AVAILABLE=100
+DNF_EXIT_TIMEOUT=124
+
+# --- Functions ---
+
+# Function to check DNF (Fedora) updates
+# Returns:
+#   "0": No updates
+#   <number>: Number of updates
+#   "!": Timeout
+#   "?": Error
+get_dnf_update_count() {
+  local dnf_output
+  local dnf_exit_status
+  local count
+
   # Use timeout command to kill after 15 seconds if stuck
-  timeout 15 dnf check-update --refresh -y 2>/dev/null
-  return $?
+  # -y to automatically answer yes to any prompts like GPG key imports
+  dnf_output=$(timeout 15 dnf check-update --refresh -y 2>/dev/null)
+  dnf_exit_status=$?
+
+  if [ $dnf_exit_status -eq $DNF_EXIT_OK ]; then
+    count="0"
+  elif [ $dnf_exit_status -eq $DNF_EXIT_UPDATES_AVAILABLE ]; then
+    # Count actual package lines (excluding headers and empty lines)
+    count=$(echo "$dnf_output" | grep -v "^Last metadata" | grep -v "^$" | grep -v "^Upgrade" | wc -l | tr -d ' ')
+  elif [ $dnf_exit_status -eq $DNF_EXIT_TIMEOUT ]; then
+    count="!" # Timeout indicator
+  else
+    count="?" # Any other exit code indicates an error
+  fi
+  echo "$count"
 }
 
-# First try with auto-confirmation for GPG keys
-dnf_output=$(run_dnf_with_timeout)
-dnf_exit=$?
+# Function to check Flatpak updates
+# Returns:
+#   "0": No updates
+#   <number>: Number of updates
+#   "?": Error
+get_flatpak_update_count() {
+  local flatpak_output
+  local flatpak_exit_status
+  local count
 
-if [ $dnf_exit -eq 0 ]; then
-  # No updates available
-  fedora_count="0"
-elif [ $dnf_exit -eq 100 ]; then
-  # Updates available - count actual package lines (excluding headers and empty lines)
-  fedora_count=$(echo "$dnf_output" | grep -v "^Last metadata" | grep -v "^$" | grep -v "^Upgrade" | wc -l | tr -d ' ')
-elif [ $dnf_exit -eq 124 ]; then
-  # Exit code 124 means the timeout command killed the process
-  fedora_count="!"  # Use ! to indicate timeout
-else
-  # Any other exit code indicates an error
-  fedora_count="?"
-fi
+  # First try with remote-ls --updates which is more reliable
+  flatpak_output=$(flatpak remote-ls --updates 2>/dev/null)
+  flatpak_exit_status=$?
 
-# ------------- Flatpak Update Info -------------
-# First try with remote-ls --updates which is more reliable
-flatpak_output=$(flatpak remote-ls --updates 2>/dev/null)
-flatpak_exit=$?
-
-if [ $flatpak_exit -eq 0 ]; then
-  if [ -z "$flatpak_output" ]; then
-    flatpak_count="0"
+  if [ $flatpak_exit_status -eq 0 ]; then
+    if [ -z "$flatpak_output" ]; then
+      count="0"
+    else
+      # Count lines in the output for available updates
+      count=$(echo "$flatpak_output" | grep -v "^$" | wc -l | tr -d ' ')
+    fi
   else
-    # Count lines in the output for available updates
-    flatpak_count=$(echo "$flatpak_output" | grep -v "^$" | wc -l | tr -d ' ')
-  fi
-else
-  # Fallback to the original method if remote-ls fails
-  flatpak_output=$(flatpak update --no-deploy 2>/dev/null || echo "Error")
+    # Fallback to the original method if remote-ls fails
+    flatpak_output=$(flatpak update --no-deploy 2>/dev/null || echo "Error")
 
-  if [ "$flatpak_output" = "Error" ]; then
-    flatpak_count="?"
-  elif echo "$flatpak_output" | grep -q "Nothing to do."; then
-    flatpak_count="0"
-  else
-    # Count update lines with a more flexible pattern
-    flatpak_count=$(echo "$flatpak_output" | grep -E '^\s*[0-9]+\.\s+' | wc -l | tr -d ' ')
-    if [ "$flatpak_count" = "0" ] && ! echo "$flatpak_output" | grep -q "Nothing to do."; then
-      flatpak_count="?"
+    if [ "$flatpak_output" = "Error" ]; then
+      count="?"
+    elif echo "$flatpak_output" | grep -q "Nothing to do."; then
+      count="0"
+    else
+      # Count update lines with a more flexible pattern
+      count=$(echo "$flatpak_output" | grep -E '^\s*[0-9]+\.\s+' | wc -l | tr -d ' ')
+      # If count is 0 but "Nothing to do" is not found, it's likely an error or unexpected output
+      if [ "$count" = "0" ] && ! echo "$flatpak_output" | grep -q "Nothing to do."; then
+        count="?"
+      fi
     fi
   fi
-fi
+  echo "$count"
+}
+
+# --- Main Script ---
+
+# ------------- DNF (Fedora) Update Info -------------
+fedora_count=$(get_dnf_update_count)
+
+# ------------- Flatpak Update Info -------------
+flatpak_count=$(get_flatpak_update_count)
 
 # ------------- Combined Output -------------
 # Store original values before formatting for combined status check
@@ -75,8 +131,6 @@ original_flatpak="$flatpak_count"
 [ "$fedora_count" = "!" ] && fedora_count="⏱️" # Timeout indicator
 [ "$fedora_count" = "?" ] && fedora_count="❓" # Error indicator
 [ "$flatpak_count" = "?" ] && flatpak_count="❓" # Error indicator
-
-FEDORA_ICON=$'\uf30a' # FontAwesome Fedora logo
 
 # If both systems are up-to-date (both original values were "0"), show only a single check mark
 if [ "$original_fedora" = "0" ] && [ "$original_flatpak" = "0" ]; then

--- a/package-management/fedora-flatpak-status.sh
+++ b/package-management/fedora-flatpak-status.sh
@@ -63,6 +63,10 @@ else
 fi
 
 # ------------- Combined Output -------------
+# Store original values before formatting for combined status check
+original_fedora="$fedora_count"
+original_flatpak="$flatpak_count"
+
 # Show checkmark instead of "0" for better readability
 [ "$fedora_count" = "0" ] && fedora_count="✅"
 [ "$flatpak_count" = "0" ] && flatpak_count="✅"
@@ -74,4 +78,9 @@ fi
 
 FEDORA_ICON=$'\uf30a' # FontAwesome Fedora logo
 
-echo "$FEDORA_ICON : $fedora_count | 📦: $flatpak_count"
+# If both systems are up-to-date (both original values were "0"), show only a single check mark
+if [ "$original_fedora" = "0" ] && [ "$original_flatpak" = "0" ]; then
+  echo "✅ Up-to-date"
+else
+  echo "$FEDORA_ICON : $fedora_count | 📦: $flatpak_count"
+fi

--- a/system/info/storage.sh
+++ b/system/info/storage.sh
@@ -1,4 +1,32 @@
 #!/bin/sh
+# Copyright (c) 2025, Cyber-Syntax Serif
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 # Define mount points to check
 mounts=("/" "/home" "/root" "/backup" "/nix")
 warning=20
@@ -12,7 +40,7 @@ for m in "${mounts[@]}"; do
   # Get the df output for the mount point (skip error if mount not found)
   df_line=$(df -h -P -l "$m" 2>/dev/null | tail -n 1)
   [ -z "$df_line" ] && continue
-  
+
   # Parse fields from df output: Filesystem, Size, Used, Avail, Use%, Mounted on
   filesystem=$(echo "$df_line" | awk '{print $1}')
   size=$(echo "$df_line" | awk '{print $2}')
@@ -20,11 +48,11 @@ for m in "${mounts[@]}"; do
   avail=$(echo "$df_line" | awk '{print $4}')
   usepct=$(echo "$df_line" | awk '{print $5}')
   mountpoint=$(echo "$df_line" | awk '{print $6}')
-  
+
   # Remove the trailing % from the use percentage
   usepct_num=$(echo "$usepct" | tr -d '%')
   free=$(expr 100 - "$usepct_num")
-  
+
   # Determine the mount point's severity
   mount_class=""
   if [ "$free" -lt "$critical" ]; then
@@ -32,7 +60,7 @@ for m in "${mounts[@]}"; do
   elif [ "$free" -lt "$warning" ]; then
     mount_class="warning"
   fi
-  
+
   # Only add mount points that are under the defined free-space threshold
   if [ -n "$mount_class" ]; then
     output="${output}[${m}: ${free}% free] "


### PR DESCRIPTION
Introduce a timeout for dnf update checks to enhance reliability and prevent hanging on GPG key prompts. Improve the output format for update status, ensuring clarity when both Fedora and Flatpak are up-to-date. Update copyright information in scripts and add a deployment script for easier installation of scripts to XDG base directories.